### PR TITLE
Introduce "step" component into Abstract Test encoding

### DIFF
--- a/sources/standard/abstract_tests/ADE/ATS_ADE_Elements.adoc
+++ b/sources/standard/abstract_tests/ADE/ATS_ADE_Elements.adoc
@@ -6,34 +6,42 @@
 To validate that Application Domain Extension s (ADE) to the CityGML Conceptual Model are implemented correctly.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each new UML class defined by an ADE:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that every Feature Type class in an ADE is derived either directly or indirectly from the CityGML root Feature Type _core:AbstractFeature_ or a subclass thereof.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that every UML class in an ADE which represents a top-level Feature Type is assigned the _&#171;TopLevelFeatureType&#187;_ stereotype.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that every UML class in an ADE which represents spaces or space boundaries is derived either directly or indirectly from _core:AbstractSpace_ or _core:AbstractSpaceBoundary_ respectively.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that any new or additional spatial properties defined by an ADE:
 
 . belongs to a predefined LOD,
 . has a property name which starts with the prefix “lod__X__”, where _X_ is an integer value indicating the target LOD.
 --
+
+======
+=====
 ====
 

--- a/sources/standard/abstract_tests/ADE/ATS_ADE_Properties.adoc
+++ b/sources/standard/abstract_tests/ADE/ATS_ADE_Properties.adoc
@@ -3,30 +3,37 @@
 ====
 [.component,class=test-purpose]
 --
-To validate that Application Domain Extension s (ADE) to the CityGML Conceptual Model implement extension properties correctly.
+To validate that Application Domain Extensions (ADE) to the CityGML Conceptual Model implement extension properties correctly.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 Every Feature Type in the CityGML Conceptual Model includes an extension property whos' purpose is to allow an ADE to add properties to that existing Feature Type. In every case where an extension property has been used:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the ADE creates a subclass of the abstract data type associated with the extension property.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that this subclass is defined as a data type using the stereotype _&#171;DataType&#187;_.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that all application-specific attributes and associations for that Feature Type are modeled as properties of the ADE subclass.
 --
+======
+=====
 ====
 
 

--- a/sources/standard/abstract_tests/ADE/ATS_ADE_UML.adoc
+++ b/sources/standard/abstract_tests/ADE/ATS_ADE_UML.adoc
@@ -6,26 +6,33 @@
 To validate that Application Domain Extensions (ADE) to the CityGML Conceptual Model are modeled correctly in UML.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 An ADE is defined as conceptual model in UML in accordance with the conceptual modeling framework of the ISO 19100 series of International Standards
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the ADE UML model adheres to the General Feature Model as specified in ISO 19109.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the ADE UML model adheres to rules and constraints for application schemas as specified in ISO/TS 19103.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the ADE UML model is organized into one or more UML packages having globally unique namespaces and containing all UML model elements defined by the ADE.
 --
+======
+=====
 ====
 

--- a/sources/standard/abstract_tests/Appearance/ATS_Appearance_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Appearance/ATS_Appearance_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Appearance Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Appearance/ATS_Appearance_Classes.adoc
+++ b/sources/standard/abstract_tests/Appearance/ATS_Appearance_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Appearance Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Bridge/ATS_Bridge_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Bridge/ATS_Bridge_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Bridge Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Bridge/ATS_Bridge_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Bridge/ATS_Bridge_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Bridge Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Bridge/ATS_Bridge_Classes.adoc
+++ b/sources/standard/abstract_tests/Bridge/ATS_Bridge_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Bridge Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Building/ATS_Building_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Building/ATS_Building_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Building Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Building/ATS_Building_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Building/ATS_Building_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Building Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Building/ATS_Building_Classes.adoc
+++ b/sources/standard/abstract_tests/Building/ATS_Building_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Building Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the CityFurniture Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_Boundaries.adoc
+++ b/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the CityFurniture Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_Classes.adoc
+++ b/sources/standard/abstract_tests/CityFurniture/ATS_CityFurniture_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the CityFurniture Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the CityObjectGroup Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_Boundaries.adoc
+++ b/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the CityObjectGroup Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_Classes.adoc
+++ b/sources/standard/abstract_tests/CityObjectGroup/ATS_CityObjectGroup_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the CityObjectGroup Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Construction/ATS_Construction_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Construction/ATS_Construction_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Construction Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Construction/ATS_Construction_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Construction/ATS_Construction_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Construction Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Construction/ATS_Construction_Classes.adoc
+++ b/sources/standard/abstract_tests/Construction/ATS_Construction_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Construction Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Core/ATS_Core_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Core/ATS_Core_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Core Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Core/ATS_Core_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Core/ATS_Core_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Core Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Core/ATS_Core_Classes.adoc
+++ b/sources/standard/abstract_tests/Core/ATS_Core_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
-For each UML class defined or referenced in the Core Package:
+[.component,class=test method]
+=====
 
-[.component,class=part]
+[.component,class=step]
+======
+For each UML class defined or referenced in the Tunnel Package:
+
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Core/ATS_Core_ISO.adoc
+++ b/sources/standard/abstract_tests/Core/ATS_Core_ISO.adoc
@@ -6,18 +6,21 @@
 To validate that none of the restrictions which the CityGML Conceptual Model imposes on ISO classes are violated by an Implementation Specification.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
-[.component,class=part]
+[.component,class=test method]
+=====
+[.component,class=step]
 --
 For each instance of the GM_Solid class, validate that there are no interior boundaries associated with that instance.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 For each instance of a class descended from the GM_Solid class, validate that there are no interior boundaries associated with that instance.
 --
+=====
 ====

--- a/sources/standard/abstract_tests/Dynamizer/ATS_Dynamizer_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Dynamizer/ATS_Dynamizer_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Dynamizer Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Dynamizer/ATS_Dynamizer_Classes.adoc
+++ b/sources/standard/abstract_tests/Dynamizer/ATS_Dynamizer_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Dynamizer Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Generics/ATS_Generics_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Generics/ATS_Generics_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Generics Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Generics/ATS_Generics_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Generics/ATS_Generics_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Generics Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Generics/ATS_Generics_Classes.adoc
+++ b/sources/standard/abstract_tests/Generics/ATS_Generics_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Generics Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Generics/ATS_Generics_Use.adoc
+++ b/sources/standard/abstract_tests/Generics/ATS_Generics_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Generics are not used in a way that duplicates or conflicts with feature classes or attributes defined in the Conceptual Model..
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For all Generics-based classes and attributes defined in the Implementation Specification:
 
-[.component,class=part]
+[.component,class=step]
 --
 Demonstrate that this class or attribute does not duplicate or conflict with any classes or attributes defined in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/LandUse/ATS_LandUse_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/LandUse/ATS_LandUse_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the LandUse Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/LandUse/ATS_LandUse_Classes.adoc
+++ b/sources/standard/abstract_tests/LandUse/ATS_LandUse_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the LandUse Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/PointCloud/ATS_PointCloud_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/PointCloud/ATS_PointCloud_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the PointCloud Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/PointCloud/ATS_PointCloud_Classes.adoc
+++ b/sources/standard/abstract_tests/PointCloud/ATS_PointCloud_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the PointCloud Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Relief/ATS_Relief_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Relief/ATS_Relief_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Relief Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Relief/ATS_Relief_Classes.adoc
+++ b/sources/standard/abstract_tests/Relief/ATS_Relief_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Relief Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Transportation/ATS_Transportation_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Transportation/ATS_Transportation_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Transportation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Transportation/ATS_Transportation_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Transportation/ATS_Transportation_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Transportation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Transportation/ATS_Transportation_Classes.adoc
+++ b/sources/standard/abstract_tests/Transportation/ATS_Transportation_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Transportation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Tunnel Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Tunnel Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_Classes.adoc
+++ b/sources/standard/abstract_tests/Tunnel/ATS_Tunnel_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Tunnel Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Vegetation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_Boundaries.adoc
+++ b/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_Boundaries.adoc
@@ -7,16 +7,23 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Vegetation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====
 

--- a/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_Classes.adoc
+++ b/sources/standard/abstract_tests/Vegetation/ATS_Vegetation_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Vegetation Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Versioning/ATS_Versioning_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/Versioning/ATS_Versioning_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Versioning Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/Versioning/ATS_Versioning_Classes.adoc
+++ b/sources/standard/abstract_tests/Versioning/ATS_Versioning_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Versioning Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_ADE_Use.adoc
+++ b/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_ADE_Use.adoc
@@ -6,15 +6,22 @@
 To validate that Application Data Extensions are not used unless conformance with the ADE Requirements Class can be demonstrated.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 If any ADE classes or properties are included in the Waterbody Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification conforms with the ADE Requirements Class.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_Boundaries.adoc
+++ b/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_Boundaries.adoc
@@ -6,15 +6,22 @@
 To validate that the Implementation Specification does not specify boundaries except as defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Waterbody Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification does not specify boundaries for the UML class except as specified in the Conceptual Model.
 --
+======
+=====
 ====

--- a/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_Classes.adoc
+++ b/sources/standard/abstract_tests/WaterBody/ATS_Waterbody_Classes.adoc
@@ -6,40 +6,47 @@
 To validate that the Implementation Specification correctly implements the UML Classes defined in the Conceptual Model.
 --
 
-[.component,class=test-method]
+[.component,class=test method type]
 --
 Manual Inspection
 --
 
+[.component,class=test method]
+=====
+
+[.component,class=step]
+======
 For each UML class defined or referenced in the Waterbody Package:
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification contains a data element which represents the same concept as that defined for the UML class.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same relationships with other elements as those defined for the UML class. Validate that those relationships have the same source, target, direction, roles, and multiplicies as those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the data element has the same properties (attributes) as those specified for the UML class. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model.
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the properties of the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those properties have the same name, definition, type, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the associations represented for the data element include those of all superclasses of the UML class as documented in the Conceptual Model. Validate that those representations have the same source, target, roles, and multiplicity of those documented in the Conceptual Model
 --
 
-[.component,class=part]
+[.component,class=step]
 --
 Validate that the Implementation Specification enforces all constraints imposed on the UML class by the Conceptual Model
 --
+======
+=====
 ====


### PR DESCRIPTION
*As requested in https://github.com/metanorma/ogc-citygml-xmi/issues/48*

This changes are applied only for *Abstract Tests*.
*Requirement, Permission and Recommendation* encodings were not touched.

Thanks!